### PR TITLE
Fixed windows deploy via proxy

### DIFF
--- a/app/views/unattended/provisioning_templates/iPXE/windows_default_ipxe_httpboot.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/windows_default_ipxe_httpboot.erb
@@ -1,0 +1,23 @@
+<%#
+kind: iPXE
+name: Windows default iPXE httpboot
+model: ProvisioningTemplate
+oses:
+- Windows
+description: |
+  The template to render iPXE installation script for Windows
+  The output is deployed on the host's subnet TFTP proxy.
+  See https://ipxe.org/scripting for more details
+-%>
+#!ipxe
+
+set boot-url http://<%= foreman_request_addr %>/httpboot/
+kernel ${boot-url}<%= @host.operatingsystem.bootfile(medium_provider,:kernel) %>
+
+initrd <%= foreman_url('script') %> peSetup.cmd
+
+initrd ${boot-url}<%= @host.operatingsystem.bootfile(medium_provider,:bcd) %> BCD
+initrd ${boot-url}<%= @host.operatingsystem.bootfile(medium_provider,:bootsdi) %> boot.sdi
+initrd ${boot-url}<%= @host.operatingsystem.bootfile(medium_provider,:bootwim) %> boot.wim
+
+boot


### PR DESCRIPTION
Fixed windows deploy via proxy.
You can use it to provision hosts running Windows using iPXE over HTTP instead of TFTP Only need to use httpboot to do this.
`set boot-url tftp://<%= foreman_request_addr %>/` changed to
`set boot-url http://<%= foreman_request_addr %>/httpboot/`


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
